### PR TITLE
Add stringsAsFactor=FALSE for R 3.x users

### DIFF
--- a/code/data-processing/download-historical-healthdata.R
+++ b/code/data-processing/download-historical-healthdata.R
@@ -21,7 +21,8 @@ temp <- httr::GET(
 timeseries_revisions_meta <- data.frame(
   issue_date = lubridate::ymd(substr(temp$update_date, 1, 10)), # actually the file creation date, not the issue date
   issue_datetime = temp$update_date,
-  file_link = temp$archive_link$url
+  file_link = temp$archive_link$url,
+  stringsAsFactors = FALSE
 ) %>%
   dplyr::filter(
     !(substr(file_link, nchar(file_link) - 3, nchar(file_link)) == "zip"),
@@ -44,7 +45,8 @@ daily_revisions_meta <- data.frame(
   issue_date = lubridate::ymd(substr(temp$update_date, 1, 10)), # actually the file creation date, not the issue date
   date = lubridate::ymd(substr(temp$update_date, 1, 10)),
   issue_datetime = temp$update_date,
-  file_link = temp$archive_link$url
+  file_link = temp$archive_link$url,
+  stringsAsFactors = FALSE
 ) %>%
   dplyr::filter(
     !(substr(file_link, nchar(file_link) - 3, nchar(file_link)) == "zip"),


### PR DESCRIPTION
For R 3.x users, they may run into error, since `stringsAsFactors=TRUE` is default when creating data.frames. For R 4.x users this is not the case, so the error will not happen:

`Error: Problem with `filter()` input `..1`.
✖ 'nchar()' requires a character vector
ℹ Input `..1` is `!...`.
Backtrace:
     █
  1. ├─`%>%`(...)
  2. ├─dplyr::slice_max(., issue_datetime)
  3. ├─dplyr::group_by(., issue_date)
  4. ├─dplyr::filter(...)
  5. ├─dplyr:::filter.data.frame(...)
  6. │ └─dplyr:::filter_rows(.data, ...)
  7. │   ├─base::withCallingHandlers(...)
  8. │   └─mask$eval_all_filter(dots, env_filter)
  9. ├─base::substr(file_link, nchar(file_link) - 3, nchar(file_link))
 10. ├─base::nchar(file_link)
 11. └─base::.handleSimpleError(...)
 12.   └─dplyr:::h(simpleError(msg, call))`

Solution: add `stringsAsFactors = FALSE` to where data.frames is created

Reference: https://stackoverflow.com/questions/60849678/why-does-r-convert-numbers-and-characters-to-factors-when-coercing-to-data-frame