### PR TITLE
remove scheduled runs of data link update actions

### DIFF
--- a/.github/workflows/update_time_series_links.yaml
+++ b/.github/workflows/update_time_series_links.yaml
@@ -5,9 +5,6 @@ on:
       name:
         description: 'Update time series data links'
         required: false
-  schedule:
-    - cron: "0 0 * * *"
-    - cron: "0 17 * * *"
 
 jobs:
   update_time_series_links:

--- a/.github/workflows/update_time_series_links_csv.yaml
+++ b/.github/workflows/update_time_series_links_csv.yaml
@@ -5,9 +5,6 @@ on:
       name:
         description: 'Update time series data links'
         required: false
-  schedule:
-    - cron: "10 0 * * *"
-    - cron: "10 17 * * *"
 
 jobs:
   update_time_series_links_csv:


### PR DESCRIPTION
These actions don't need to run anymore, because they register git commits associated with data updates in the JHU covid data repo, which are no longer made or used.